### PR TITLE
Improve: assign test name from @TestInput.name()

### DIFF
--- a/rdfunit-junit/src/main/java/org/aksw/rdfunit/junit/RdfUnitJunitRunner.java
+++ b/rdfunit-junit/src/main/java/org/aksw/rdfunit/junit/RdfUnitJunitRunner.java
@@ -220,10 +220,15 @@ public class RdfUnitJunitRunner extends ParentRunner<RdfUnitJunitTestCase> {
                 child.getTestInputMethod().getDeclaringClass(),
                 String.format(
                         "[%s] %s",
-                        child.getTestInputMethod().getMethod().getName(),
+                        getTestInputBaseName(child.getTestInputMethod()),
                         child.getTestCase().getAbrTestURI()
                 )
         );
+    }
+
+    private String getTestInputBaseName(FrameworkMethod method) {
+        final String basename = method.getAnnotation(TestInput.class).name();
+        return basename.isEmpty() ? method.getName() : basename;
     }
 
     @Override

--- a/rdfunit-junit/src/main/java/org/aksw/rdfunit/junit/TestInput.java
+++ b/rdfunit-junit/src/main/java/org/aksw/rdfunit/junit/TestInput.java
@@ -11,4 +11,8 @@ import java.lang.annotation.*;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
-public @interface TestInput {}
+public @interface TestInput {
+
+    String name() default "";
+
+}


### PR DESCRIPTION
`@TestInput` supports setting a dedicated name that is used to generate Test descriptions.
